### PR TITLE
v2: better error messages, remove document.cookie, rename RouteResult and EndpointArg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# 2.0.0
+
+**This is a backwards-incompatible release.**
+
+- `ControllerMethod` no longer allows you to return a non-`Promise`, as the sum type led to longer, confusing TypeScript error messages. TypeScript's UX around generics and disjunctions needs work, so we might revisit this decision as the compiler improves
+
+- `document.cookie` support removed. We might bring this back in the future, but we wanted to enable end-users to write services that did not rely on cookie-based CSRF protection.
+
+- We renamed the type arguments `RouteResult, EndpointArg` to `TResponse, TRequest` and reordered them to `TRequest, TResponse`. This should more accurately reflect what those types do, especially for POST and PUT requests. The previous order led to slightly unidiomatic code, where the type of the request came after the type of the response.
+
+# 1.0.x
+
+- Imported the bulk of the code from another project
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@Originate/leash",
   "types": "dist/index.d.ts",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -5,14 +5,14 @@ import {RequestError} from './request_error';
 
 export {RequestError} from './request_error';
 
-export class RouteClient<RouteResult, EndpointArg> {
+export class RouteClient<TRequest, TResponse> {
   constructor(
     private method: Method,
     public endpointTemplate: string,
-    public client: (arg: EndpointArg) => Promise<Array<RouteResult>>,
+    public client: (arg: TRequest) => Promise<TResponse>,
   ) {}
 
-  install = (app: Express, controllerMethod: ControllerMethod<RouteResult>): void => {
+  install = (app: Express, controllerMethod: ControllerMethod<TResponse>): void => {
     switch (this.method) {
       case 'HEAD':
         app.head(this.endpointTemplate, this.wrap(controllerMethod));
@@ -32,7 +32,7 @@ export class RouteClient<RouteResult, EndpointArg> {
     }
   };
 
-  private wrap(controllerMethod: ControllerMethod<RouteResult>) {
+  private wrap(controllerMethod: ControllerMethod<TResponse>) {
     return async (req: Request, res: Response) => {
       try {
         const result = await Promise.resolve(controllerMethod(req, res));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,5 +7,5 @@ export * from './result';
 export type Method = 'HEAD' | 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 export interface ControllerMethod<RouteResult> {
-  (req: Request, res: ExpressResponse): Result<RouteResult> | Promise<Result<RouteResult>>;
+  (req: Request, res: ExpressResponse): Promise<Result<RouteResult>>;
 }

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -5,9 +5,9 @@ type Cookie = {
   httpOnly: boolean;
 };
 
-export interface GoodResult<T> {
+export interface GoodResult<TData> {
   cookies?: Array<Cookie>;
-  data: Array<T>;
+  data: TData;
 }
 
 export interface BadResult {
@@ -15,14 +15,14 @@ export interface BadResult {
   error?: string;
 }
 
-export type Result<T> = GoodResult<T> | BadResult;
+export type Result<TData> = GoodResult<TData> | BadResult;
 
-export function good<T>(t: T | Array<T>): Result<T> {
-  return {data: Array.isArray(t) ? t : [t]};
+export function good<TData>(data: TData): Result<TData> {
+  return {data};
 }
 
-export function goodWithSetCookie<T>(t: T | Array<T>, cookies: Array<Cookie>): Result<T> {
-  return {...good(t), cookies};
+export function goodWithSetCookie<TData>(data: TData, cookies: Array<Cookie>): Result<TData> {
+  return {...good(data), cookies};
 }
 
 export function bad(status: number, error?: string): Result<never> {


### PR DESCRIPTION
> `ControllerMethod` no longer allows you to return a non-`Promise`, as the sum type led to longer, confusing TypeScript error messages. TypeScript's UX around generics and disjunctions needs work, so we might revisit this decision as the compiler improves

For example:

```
packages/backend/index.ts:34:38 - error TS2345: Argument of type '(req: Request<ParamsDictionary, any, any, QueryString.ParsedQs>, res: Response) => BadResult | Promise<Result<types.PasswordResponse>> | GoodResult<...>' is not assignable to parameter of type 'ControllerMethod<PasswordRequest>'.
  Type 'BadResult | Promise<Result<PasswordResponse>> | GoodResult<never>' is not assignable to type 'BadResult | GoodResult<PasswordRequest> | Promise<Result<PasswordRequest>>'.
    Type 'Promise<Result<PasswordResponse>>' is not assignable to type 'BadResult | GoodResult<PasswordRequest> | Promise<Result<PasswordRequest>>'.
      Type 'Promise<Result<PasswordResponse>>' is not assignable to type 'Promise<Result<PasswordRequest>>'.
        Type 'Result<PasswordResponse>' is not assignable to type 'Result<PasswordRequest>'.
          Type 'GoodResult<PasswordResponse>' is not assignable to type 'Result<PasswordRequest>'.
            Type 'GoodResult<PasswordResponse>' is not assignable to type 'GoodResult<PasswordRequest>'.
              Type 'PasswordResponse' is not assignable to type 'PasswordRequest'.
                Type '{ ok: true; }' is missing the following properties from type 'PasswordRequest': token, password

34     authRouter.password.install(app, authController.passwordPUT);
```

This is all because I put in the wrong type, but most of the error is devoted to the type disjunctions, which got inlined and became extremely verbose.

----

> `document.cookie` support removed. We might bring this back in the future, but we wanted to enable end-users to write services that did not rely on cookie-based CSRF protection.

It was awkward to write the Authorization-based example service in COA with the mandatory CSRF token stuff that was happening. Cookie-based CSRF protection is sort of obsoleted by more advanced tools these days, and non-browser clients strongly dislike having to deal with cookies.

----

> We renamed the type arguments `RouteResult, EndpointArg` to `TResponse, TRequest` and reordered them to `TRequest, TResponse`. This should more accurately reflect what those types do, especially for POST and PUT requests. The previous order led to slightly unidiomatic code, where the type of the request came after the type of the response.

This was slightly awkward:

```tsx
  return {
    signup: Router.post<types.SignupResponse, types.SignupRequest<TSignup>>('/api/auth/signup'),
    login: Router.post<types.LoginResponse<TLogin>, types.LoginRequest>('/api/auth/login'),
    ['password-reset']: Router.post<types.PasswordResetResponse, types.PasswordResetRequest>(
      '/api/auth/password-reset',
    ),
    password: Router.put<types.PasswordResponse, types.PasswordRequest>('/api/auth/password'),
  };
}
```

The request types should definitely come first, IMO.