### PR TITLE
key errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@Originate/leash",
   "types": "dist/index.d.ts",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Two-way routing library a la Servant",
   "main": "dist/index.js",
   "scripts": {

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -12,6 +12,7 @@ export interface GoodResult<TData> {
 
 export interface BadResult {
   status: number;
+  key: string;
   error?: string;
 }
 
@@ -25,6 +26,6 @@ export function goodWithSetCookie<TData>(data: TData, cookies: Array<Cookie>): R
   return {...good(data), cookies};
 }
 
-export function bad(status: number, error?: string): Result<never> {
-  return {status, error};
+export function bad(status: number, key: string, error?: string): Result<never> {
+  return {status, key, error};
 }


### PR DESCRIPTION
This bumps the version to 2.1.4. The idea is that frontend/mobile clients shouldn't have to do string comparison on an English sentence to figure out which error they received. The "key" is yet another string, but it's designed to be a symbol (like a Ruby :symbol). For example `key: "unauthorized"` when `error: "Incorrect username or password"`.